### PR TITLE
Color Detection affecting game

### DIFF
--- a/Assets/Scenes/Adrian/Snow Level.unity
+++ b/Assets/Scenes/Adrian/Snow Level.unity
@@ -1821,6 +1821,136 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1399878650}
   m_Mesh: {fileID: 3950978165454200217, guid: 9ec6a8fc6925acb4abc5500eeecb8270, type: 3}
+--- !u!1 &1590975330
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1590975335}
+  - component: {fileID: 1590975334}
+  - component: {fileID: 1590975333}
+  - component: {fileID: 1590975332}
+  - component: {fileID: 1590975331}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1590975331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590975330}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b37c101ae2235bd4d92ae5078032cdb3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  displayRenderer: {fileID: 1590975333}
+  targetColorRed: {r: 1, g: 0, b: 0, a: 1}
+  targetColorGreen: {r: 0, g: 1, b: 0, a: 1}
+  colorThreshold: 0.3
+  bombPowerUpPrefab: {fileID: 2660662142532336686, guid: c3d3155eab1257d4d97d09cc6218dbe0, type: 3}
+  greenPowerUpPrefab: {fileID: 4272861072928726269, guid: eaf78b7240882e6449f8b185508a5471, type: 3}
+  spawnObject: {fileID: 1310123871}
+  xOffset: 0
+  yOffset: 0
+  zOffset: 1
+  detectionCooldown: 2
+--- !u!64 &1590975332
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590975330}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1590975333
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590975330}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 46339bbcfa2b041499f2c8b34ce50615, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1590975334
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590975330}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1590975335
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1590975330}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.005767332, y: 0.00902166, z: -0.783833, w: 0.62087935}
+  m_LocalPosition: {x: -4.08, y: 4.1, z: -0.2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0.4, y: 1.16, z: -103.23}
 --- !u!1001 &1713801753
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2308,3 +2438,4 @@ SceneRoots:
   - {fileID: 763223092}
   - {fileID: 1286953878}
   - {fileID: 3637823059515555253}
+  - {fileID: 1590975335}

--- a/Assets/Scripts/CameraFeed.cs
+++ b/Assets/Scripts/CameraFeed.cs
@@ -5,21 +5,30 @@ public class CameraFeed : MonoBehaviour
     private WebCamTexture webcamTexture;
     public Renderer displayRenderer;
 
-    public Color targetColor = Color.red; // Color to detect
-    public float colorThreshold = 100f;   // Color detection threshold
+    public Color targetColorRed = Color.red;   // Red color to detect
+    public Color targetColorGreen = Color.green; // Green color to detect
+    public float colorThreshold = 100f;         // Color detection threshold
+    public GameObject bombPowerUpPrefab;        // Bomb prefab to spawn
+    public GameObject greenPowerUpPrefab;       // Speed power-up prefab to spawn
+    public GameObject spawnObject;              
+    public float xOffset = 1f;                  
+    public float yOffset = 0f;                  
+    public float zOffset = 1f;                 
+    public float detectionCooldown = 2f;        
+    private float lastDetectionTime = 0f;       
 
     void Start()
     {
         Debug.Log("CameraFeed script started.");
 
-        // Check if the displayRenderer is assigned
+       
         if (displayRenderer == null)
         {
             Debug.LogError("Display renderer not assigned. Camera feed will not render.");
             return;
         }
 
-        // Initialize and start the webcam texture
+        
         webcamTexture = new WebCamTexture();
         displayRenderer.material.mainTexture = webcamTexture;
 
@@ -30,7 +39,7 @@ public class CameraFeed : MonoBehaviour
 
     void Update()
     {
-        // Check if the webcam texture is playing
+        
         if (!webcamTexture.isPlaying)
         {
             Debug.LogWarning("Webcam not playing. Attempting to start...");
@@ -38,24 +47,36 @@ public class CameraFeed : MonoBehaviour
         }
 
         // Perform color detection on webcam texture frames
-        if (webcamTexture.isPlaying && webcamTexture.didUpdateThisFrame)
+        if (webcamTexture.isPlaying && webcamTexture.didUpdateThisFrame && Time.time - lastDetectionTime >= detectionCooldown)
         {
             Color[] pixels = webcamTexture.GetPixels();
 
             // Loop through each pixel in the webcam texture
             foreach (Color pixel in pixels)
             {
-                // Calculate the color difference using Euclidean distance in RGB space
-                float rDiff = pixel.r - targetColor.r;
-                float gDiff = pixel.g - targetColor.g;
-                float bDiff = pixel.b - targetColor.b;
-                float colorDifference = Mathf.Sqrt(rDiff * rDiff + gDiff * gDiff + bDiff * bDiff);
+                // Calculate the color difference for red and green colors
+                float redDifference = ColorDifference(pixel, targetColorRed);
+                float greenDifference = ColorDifference(pixel, targetColorGreen);
 
-                // If the color difference is less than the threshold, the color is detected
-                if (colorDifference < colorThreshold)
+                // Check if the pixel color is similar to red within the threshold
+                if (redDifference < colorThreshold)
                 {
-                    Debug.Log("Color detected!");
-                    // You can add more actions here based on color detection
+                    Debug.Log("Red color detected!");
+
+                    // Spawn the bomb power-up with an offset from the spawn object
+                    SpawnPowerUp(bombPowerUpPrefab);
+                    lastDetectionTime = Time.time;
+                    break; // Exit the loop once red color is detected
+                }
+                // Check if the pixel color is similar to green within the threshold
+                else if (greenDifference < colorThreshold)
+                {
+                    Debug.Log("Green color detected!");
+
+                    // Spawn the speed power-up with an offset from the spawn object
+                    SpawnPowerUp(greenPowerUpPrefab);
+                    lastDetectionTime = Time.time;
+                    break; // Exit the loop once green color is detected
                 }
             }
         }
@@ -63,11 +84,40 @@ public class CameraFeed : MonoBehaviour
 
     void OnDestroy()
     {
-        // Clean up the webcam texture when the script is destroyed
+        
         if (webcamTexture != null)
         {
             webcamTexture.Stop();
             Debug.Log("Webcam texture stopped.");
+        }
+    }
+
+    private float ColorDifference(Color color1, Color targetColor)
+    {
+        float dR = color1.r - targetColor.r;
+        float dG = color1.g - targetColor.g;
+        float dB = color1.b - targetColor.b;
+        return dR * dR + dG * dG + dB * dB;
+    }
+
+    void SpawnPowerUp(GameObject powerUpPrefab)
+    {
+        if (spawnObject != null && powerUpPrefab != null)
+        {
+            // Get the position of the spawnObject
+            Vector3 spawnPosition = spawnObject.transform.position;
+
+          
+            spawnPosition += spawnObject.transform.forward * zOffset;
+            spawnPosition += spawnObject.transform.right * xOffset;
+            spawnPosition += spawnObject.transform.up * yOffset;
+
+            
+            Instantiate(powerUpPrefab, spawnPosition, Quaternion.identity);
+        }
+        else
+        {
+            Debug.LogWarning("Spawn object or power-up prefab not assigned.");
         }
     }
 }


### PR DESCRIPTION
Made it so color detection affects gameplay. When red is seen Bomb Prefab will spawn in in front of the player. When green is detected the speed power up with spawn in front of the player. Also added a cooldown period between when colors can be detected so then it will not make the game lag.